### PR TITLE
(claude) Add GitHub issue workflow commands

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -1,0 +1,58 @@
+# Create GitHub Issue
+
+Help the user draft and publish a GitHub issue. Follow these steps exactly.
+
+## Step 1 — Gather context
+
+If the user provided a description or title with the command, use it as the starting point. Otherwise, ask them one focused question: **"What's the issue about?"** — wait for their answer before proceeding.
+
+## Step 2 — Draft the issue
+
+Based on what the user provided, draft:
+
+- **Title**: concise, imperative (e.g. "Add dark mode toggle", "Fix crash on empty input")
+- **Body**: use this template:
+
+```
+## What
+<one paragraph describing the problem or feature>
+
+## Why
+<why this matters — user impact, bug consequence, or motivation>
+
+## Acceptance criteria
+- [ ] <testable condition 1>
+- [ ] <testable condition 2>
+
+---
+🤖 Opened with [Claude Code](https://claude.ai/code)
+```
+
+Show the full draft to the user and ask: **"Looks good, or any changes?"**
+
+## Step 3 — Determine labels
+
+The `claude` label is always applied automatically (it marks issues opened by Claude Code).
+
+Suggest one additional label based on the content:
+- `bug` — something is broken
+- `enhancement` — new feature or improvement
+- `question` — needs clarification before work begins
+
+Run `gh label list` first and suggest from existing labels. Ask the user to confirm or change the additional label.
+
+## Step 4 — Publish the issue
+
+Once the user confirms, run:
+
+```bash
+gh issue create --title "<title>" --body "<body>" --label "<label1>,<label2>"
+```
+
+## Step 5 — Confirm and offer next steps
+
+Print the issue URL returned by `gh issue create`.
+
+Then ask: **"Should I start working on this now?"**
+- If yes → invoke `/new-branch` with the issue title and number as context, then begin implementation
+- If no → done

--- a/.claude/commands/new-branch.md
+++ b/.claude/commands/new-branch.md
@@ -10,6 +10,11 @@ Derive a short, kebab-case branch name from the user's request:
 - Refactors → `claude/refactor/<short-description>` (e.g. `claude/refactor/add-user-function`)
 - Keep it under 50 characters total
 
+If the user provides a GitHub issue number (or this command was chained from `/create-issue`), append it to the branch name:
+- e.g. `claude/feat/add-login-page#42`
+
+This lets `/open-pr` auto-detect the linked issue later.
+
 ## Step 2 — Check git status
 
 Run `git status` to confirm the repo is clean (or note any uncommitted work). If the working tree is dirty, tell the user and ask whether to stash, commit, or abort.

--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -1,0 +1,59 @@
+# Open Pull Request
+
+Open a GitHub Pull Request for the current branch. Follow these steps exactly.
+
+## Step 1 — Get current branch
+
+Run `git branch --show-current`. If the result is `main` or `master`, stop and tell the user: "You're already on main — switch to a feature branch first."
+
+## Step 2 — Detect linked issue
+
+Check the branch name for an issue number encoded as `#<number>` (e.g. `claude/feat/add-dark-mode#42`):
+- If found: extract it and tell the user "I found linked issue #<number> — I'll close it when this PR merges."
+- If not found: ask "Is this related to a GitHub issue? Provide the number to link it, or press enter to skip."
+
+## Step 3 — Build the PR title and body
+
+Run `git log main..HEAD --oneline` to see the commits on this branch.
+
+Derive a clear PR title from the branch name and commits (imperative, concise).
+
+Build the PR body using this template:
+
+```
+## Summary
+<2-3 bullet points describing what changed and why>
+
+## Test plan
+- [ ] <manual step or automated test to verify the change>
+```
+
+If a linked issue number was found or provided, append to the body:
+```
+
+Closes #<number>
+```
+
+(`Closes #N` is the GitHub magic keyword — it auto-links and closes the issue when the PR merges.)
+
+Show the full title and body to the user and ask: "Looks good, or any changes?"
+
+## Step 4 — Push the branch
+
+Run:
+```bash
+git push -u origin <branch-name>
+```
+
+## Step 5 — Create the PR
+
+Run:
+```bash
+gh pr create --title "<title>" --body "<body>" --base main
+```
+
+Print the PR URL returned by `gh`.
+
+## Step 6 — Next steps
+
+Tell the user: "PR is open. Once it's reviewed and ready to ship, run `/merge-main` to bump the version, merge, and tag."

--- a/NOTES.md
+++ b/NOTES.md
@@ -22,9 +22,14 @@ when models are downloaded, they are kept in browser's storage which is good
 - [x] show tests history
 - [x] create `/merge-main` command that merges current branch to main and asks to increment either patch, minor or major version and update it in package.json, and then add a tag with the same version on main
 - [x] implement a mechanism to clear the cache storage
-- [ ] convert this app into PWA
+- [x] convert this app into PWA
+- [ ] disable the record button if no permission
+- [ ] mobile: record button not working properly
+- [ ] mobile: add a button to force install PWA on mobile
+- [ ] fix clear cache button not updating one first time page load
 
 ## LEARN
 
 - [ ] Browser's cache storage (DevTools -> Application -> Cache Storage)
 - [ ] Browser's IndexedDB (DevTools -> Application -> IndexedDB)
+- [ ] Install Vercel Coding Agent Plugin: Turn your coding agent into a Vercel expert. Simply copy and run this in your terminal to install the plugin. Available for Claude, Cursor and Codex. `npx plugins add vercel/vercel-plugin`


### PR DESCRIPTION
## Summary
- Adds `/create-issue` command to draft and publish GitHub issues with labels and a Claude Code footer
- Adds `/open-pr` command to push branches and open PRs with optional issue linking via `Closes #N`
- Updates `/new-branch` to encode issue numbers in branch names for auto-detection by `/open-pr`

## Test plan
- [ ] Run `/create-issue` and verify issue appears on GitHub with `claude` label and footer
- [ ] Run `/open-pr` on a branch linked to an issue and verify `Closes #N` appears in the PR body
- [ ] Run `/open-pr` on an unlinked branch and verify PR is created without issue reference