### PR TITLE
(claude) Improve claude commands conventions and automation

### DIFF
--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -10,7 +10,7 @@ If the user provided a description or title with the command, use it as the star
 
 Based on what the user provided, draft:
 
-- **Title**: concise, imperative (e.g. "Add dark mode toggle", "Fix crash on empty input")
+- **Title**: prefixed with `(claude)` followed by a concise, imperative description (e.g. "(claude) Add dark mode toggle", "(claude) Fix crash on empty input")
 - **Body**: use this template:
 
 ```
@@ -24,8 +24,6 @@ Based on what the user provided, draft:
 - [ ] <testable condition 1>
 - [ ] <testable condition 2>
 
----
-🤖 Opened with [Claude Code](https://claude.ai/code)
 ```
 
 Show the full draft to the user and ask: **"Looks good, or any changes?"**

--- a/.claude/commands/merge-main.md
+++ b/.claude/commands/merge-main.md
@@ -50,9 +50,15 @@ git tag -a v<new-version> -m "v<new-version>"
 
 Confirm the tag was created by running `git tag --list v<new-version>`.
 
-## Step 8 — Summary
+## Step 8 — Push to origin
+
+```
+git push origin main && git push origin v<new-version>
+```
+
+## Step 9 — Summary
 
 Tell the user:
 - The branch that was merged
 - The new version (`v<new-version>`)
-- That they can push with: `git push origin main && git push origin v<new-version>`
+- That main and the tag have been pushed to origin

--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -16,7 +16,7 @@ Check the branch name for an issue number encoded as `#<number>` (e.g. `claude/f
 
 Run `git log main..HEAD --oneline` to see the commits on this branch.
 
-Derive a clear PR title from the branch name and commits (imperative, concise).
+Derive a clear PR title prefixed with `(claude)` followed by an imperative, concise description (e.g. "(claude) Add dark mode toggle").
 
 Build the PR body using this template:
 


### PR DESCRIPTION
## Summary
- `/create-issue` and `/open-pr` now prefix titles with `(claude)` to distinguish Claude-created items from user-created ones
- Removed the `🤖 Opened with Claude Code` footer from issue bodies
- `/merge-main` now auto-pushes `main` and the version tag to origin instead of asking the user to do it

## Test plan
- [ ] Run `/create-issue` and verify issue title starts with `(claude)`
- [ ] Run `/open-pr` and verify PR title starts with `(claude)`
- [ ] Run `/merge-main` and verify it pushes automatically without manual step