### PR TITLE
(claude) Replace open-ended prompts with y/n/type pattern across all commands

### DIFF
--- a/.claude/commands/commit-changes.md
+++ b/.claude/commands/commit-changes.md
@@ -15,9 +15,9 @@ Read the staged and unstaged changes with `git diff HEAD` to understand what cha
 - `claude (refactor): <description>` for code refactors
 - `claude (docs): <description>` for documentation changes
 
-Present the suggestion and ask: "Does this commit message work, or would you like to provide your own?"
-
-Wait for the user's response before continuing.
+Present the suggestion and prompt:
+> `y` — use this message
+> or type your own message
 
 ## Step 3 — Confirm the commit message
 

--- a/.claude/commands/create-issue.md
+++ b/.claude/commands/create-issue.md
@@ -26,7 +26,10 @@ Based on what the user provided, draft:
 
 ```
 
-Show the full draft to the user and ask: **"Looks good, or any changes?"**
+Show the full draft to the user and prompt:
+> `y` — looks good, proceed to labels
+> `n` — cancel
+> or type your change (e.g. "make the title shorter", "add a step about caching")
 
 ## Step 3 — Determine labels
 
@@ -37,7 +40,9 @@ Suggest one additional label based on the content:
 - `enhancement` — new feature or improvement
 - `question` — needs clarification before work begins
 
-Run `gh label list` first and suggest from existing labels. Ask the user to confirm or change the additional label.
+Run `gh label list` first and suggest one label. Prompt:
+> `y` — use suggested label
+> or type a different label name
 
 ## Step 4 — Publish the issue
 
@@ -51,6 +56,6 @@ gh issue create --title "<title>" --body "<body>" --label "<label1>,<label2>"
 
 Print the issue URL returned by `gh issue create`.
 
-Then ask: **"Should I start working on this now?"**
-- If yes → invoke `/new-branch` with the issue title and number as context, then begin implementation
-- If no → done
+Then prompt:
+> `y` — start working on it now (invokes `/new-branch` and begins implementation)
+> `n` — done for now

--- a/.claude/commands/merge-main.md
+++ b/.claude/commands/merge-main.md
@@ -8,9 +8,10 @@ Read `package.json` and extract the current `version` field. Display it to the u
 
 ## Step 2 — Ask which semver segment to bump
 
-Ask the user: "Which part of the version should be incremented: **patch**, **minor**, or **major**?"
-
-Wait for their answer before continuing.
+Prompt:
+> `patch` — bug fixes, small tweaks (e.g. 1.4.1 → 1.4.2)
+> `minor` — new features, backwards-compatible (e.g. 1.4.1 → 1.5.0)
+> `major` — breaking changes (e.g. 1.4.1 → 2.0.0)
 
 ## Step 3 — Calculate the new version
 
@@ -23,7 +24,10 @@ Tell the user the new version before proceeding.
 
 ## Step 4 — Check for uncommitted changes
 
-Run `git status`. If the working tree is dirty, tell the user and ask whether to commit the changes first, stash them, or abort. Do not proceed until the tree is clean.
+Run `git status`. If the working tree is dirty, prompt:
+> `commit` — stage and commit changes first
+> `stash` — stash changes and proceed
+> `abort` — stop here
 
 ## Step 5 — Update package.json
 

--- a/.claude/commands/new-branch.md
+++ b/.claude/commands/new-branch.md
@@ -17,7 +17,10 @@ This lets `/open-pr` auto-detect the linked issue later.
 
 ## Step 2 — Check git status
 
-Run `git status` to confirm the repo is clean (or note any uncommitted work). If the working tree is dirty, tell the user and ask whether to stash, commit, or abort.
+Run `git status` to confirm the repo is clean (or note any uncommitted work). If the working tree is dirty, prompt:
+> `stash` — stash changes and proceed
+> `commit` — commit changes first
+> `abort` — stop here
 
 ## Step 3 — Create and switch to the branch
 

--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -10,7 +10,9 @@ Run `git branch --show-current`. If the result is `main` or `master`, stop and t
 
 Check the branch name for an issue number encoded as `#<number>` (e.g. `claude/feat/add-dark-mode#42`):
 - If found: extract it and tell the user "I found linked issue #<number> — I'll close it when this PR merges."
-- If not found: ask "Is this related to a GitHub issue? Provide the number to link it, or press enter to skip."
+- If not found: prompt:
+  > `n` — no linked issue, skip
+  > or type the issue number (e.g. `4`)
 
 ## Step 3 — Build the PR title and body
 
@@ -36,7 +38,10 @@ Closes #<number>
 
 (`Closes #N` is the GitHub magic keyword — it auto-links and closes the issue when the PR merges.)
 
-Show the full title and body to the user and ask: "Looks good, or any changes?"
+Show the full title and body to the user and prompt:
+> `y` — looks good, push and create the PR
+> `n` — cancel
+> or type your change (e.g. "change the title", "add a test step")
 
 ## Step 4 — Push the branch
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -10,7 +10,9 @@
       "Bash(git merge:*)",
       "Bash(git tag:*)",
       "Bash(cat /Users/macbook/Desktop/www/claude-code-transformer-js-whisper-models/next.config.*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(gh label:*)",
+      "Bash(gh issue:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- All slash commands now present structured prompts (`y` / `n` / type your change) instead of open-ended questions, reducing required typing
- Covers /create-issue, /open-pr, /commit-changes, /new-branch, and /merge-main
- Also adds `gh label` and `gh issue` to allowed bash commands in settings.local.json

## Test plan
- [ ] Run /create-issue and verify prompts show y/n/type options at each decision point
- [ ] Run /commit-changes and verify the message confirmation uses the new prompt style
- [ ] Run /merge-main and verify patch/minor/major are shown as selectable options