### PR TITLE
(claude) Fix mobile UI layout and add collapsible models section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,6 +80,7 @@ export default function Home() {
   const { entries, addEntry, deleteEntry } = useTranscriptionHistory();
   const [workerKey, setWorkerKey] = useState(0);
   const [shouldAutoLoad, setShouldAutoLoad] = useState(true);
+  const [modelsExpanded, setModelsExpanded] = useState(true);
   const workerRef = useRef<Worker | null>(null);
 
   // Resolvers keyed by modelId — used to await MODEL_READY / TRANSCRIPTION_RESULT
@@ -278,8 +279,43 @@ export default function Home() {
           />
         </div>
 
-        {/* Download progress (hidden once all ready) */}
-        <DownloadPanel modelStates={state.modelStates} />
+        {/* Models collapsible */}
+        <div>
+          <button
+            onClick={() => setModelsExpanded((v) => !v)}
+            className="flex items-center gap-2 text-sm font-medium text-gray-400 hover:text-gray-200 transition-colors mb-3"
+          >
+            <svg
+              className={`w-4 h-4 transition-transform ${modelsExpanded ? "rotate-90" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            Models
+            {!modelsExpanded && (
+              <span className="text-xs text-gray-600">
+                ({allModelsReady ? "ready" : "loading…"})
+              </span>
+            )}
+          </button>
+          {modelsExpanded && (
+            <div className="space-y-4">
+              <DownloadPanel modelStates={state.modelStates} />
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                {MODEL_IDS.map((modelId) => (
+                  <ModelCard
+                    key={modelId}
+                    modelId={modelId}
+                    state={state.modelStates[modelId]}
+                    referenceText={state.referenceText}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
 
         {/* Reference text + record */}
         <div className="flex flex-col sm:flex-row gap-6 sm:items-start">
@@ -301,18 +337,6 @@ export default function Home() {
               reportDenied={reportDenied}
             />
           </div>
-        </div>
-
-        {/* Model result cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {MODEL_IDS.map((modelId) => (
-            <ModelCard
-              key={modelId}
-              modelId={modelId}
-              state={state.modelStates[modelId]}
-              referenceText={state.referenceText}
-            />
-          ))}
         </div>
 
         {/* Transcription history */}


### PR DESCRIPTION
## Summary
- Center record button on mobile by making its wrapper full-width on small viewports
- Stretch reference textarea to full row width on mobile (was clipped due to `items-start`)
- Wrap download panel and model cards in a collapsible "Models" section to reduce visual clutter, with a status indicator when collapsed

## Test plan
- [ ] On mobile: verify record button is horizontally centered
- [ ] On mobile: verify reference textarea spans the full row width
- [ ] Click "Models" toggle to collapse/expand the section
- [ ] When collapsed, verify status shows "(ready)" or "(loading…)"

Closes #1