### PR TITLE
(claude) Disable record button until microphone permission is granted

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -318,7 +318,7 @@ export default function Home() {
           <div className="flex items-center justify-center pt-6 w-full sm:w-auto">
             <RecordButton
               onRecordingComplete={handleRecordingComplete}
-              disabled={!allModelsReady || state.isTranscribing}
+              disabled={!allModelsReady || state.isTranscribing || micPermission !== "granted"}
               reportGranted={reportGranted}
               reportDenied={reportDenied}
             />


### PR DESCRIPTION
## Summary
- Record button was enabled by default regardless of microphone permission state
- Added `micPermission !== "granted"` to the button's `disabled` condition in `page.tsx`
- The existing `useMicPermission` hook already tracks live permission changes, so the button enables automatically once the user grants access

## Test plan
- [ ] Load the app in a browser with mic permission not yet granted — record button should be disabled
- [ ] Grant mic permission — record button should enable without a page reload
- [ ] Deny mic permission — record button should remain disabled

Closes #13